### PR TITLE
优化readme格式，并且增加一项编译说明，close issue #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@
 - 短视频APP拦截
 
 - 安全搜索
+
+## 编译说明
+
+本app依赖于```dnsmasq-full```，与OpenWrt默认的```dnsmasq```冲突，所以编译时请确保已经取消勾选```base-system -> dnsmasq```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # 基于DNS的广告过滤 for OpenWrt
 
-### 支持 AdGuardHome/Host/DNSMASQ/Domain 格式的规则订阅
+## 功能
 
-### 规则自动识别, 自动去重, 定时更新
+- 支持 AdGuardHome/Host/DNSMASQ/Domain 格式的规则订阅
 
-### 自定义黑白名单 
+- 规则自动识别, 自动去重, 定时更新
 
-### 短视频APP拦截
+- 自定义黑白名单
 
-### 安全搜索
+- 短视频APP拦截
 
+- 安全搜索


### PR DESCRIPTION
原来的readme在一级标题下直接使用三级标题，不是很符合markdown的最佳实践。
另外，使用官方源码编译时，需要注意手动解决编译冲突，应该在readme中有所说明。